### PR TITLE
fix tonkenizer

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -293,7 +293,7 @@ class Tokenizer {
 					terminated = true;
 				}
 			}
-			if (ch == 0) {
+			if (this.pos == this.max - 1) {
 				throw new InternalParseException(new SpelParseException(this.expressionString, start,
 						SpelMessage.NON_TERMINATING_QUOTED_STRING));
 			}
@@ -318,7 +318,7 @@ class Tokenizer {
 					terminated = true;
 				}
 			}
-			if (ch == 0) {
+			if (this.pos == this.max - 1) {
 				throw new InternalParseException(new SpelParseException(this.expressionString,
 						start, SpelMessage.NON_TERMINATING_DOUBLE_QUOTED_STRING));
 			}


### PR DESCRIPTION
It uses the `ch == 0` to check whether this expression reaches end, makes it is impossible to use `\0` in Spring EL:
```
#{#str?.split('\0')}
```